### PR TITLE
Revert "auto-update to linux-5.5.7.tar.xz"

### DIFF
--- a/cmd/rtr7-build-kernel/build.go
+++ b/cmd/rtr7-build-kernel/build.go
@@ -26,7 +26,7 @@ import (
 )
 
 // see https://www.kernel.org/releases.json
-var latest = "https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.5.7.tar.xz"
+var latest = "https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.5.6.tar.xz"
 
 const configAddendum = `
 CONFIG_IPV6=y


### PR DESCRIPTION
Reverts rtr7/kernel#132

CI didn’t actually build, so let’s try this again